### PR TITLE
Include tests in the sdist tarball on pypi

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ include setup.cfg
 include requirements-dev.txt
 include tox.ini
 include doc/*
+recursive-include tests *.py
 
 global-exclude *.py[cod]


### PR DESCRIPTION
This is used by distributors to validate the sanity of their python stack.