### PR TITLE
Handle LC_ALL and LANG Environment Variable in Tests

### DIFF
--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -25,6 +25,7 @@ import datetime
 import io
 import locale
 import math
+import os
 import time
 from decimal import Decimal
 
@@ -59,6 +60,16 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
 
     def setUp(self):
         self.parser = XPath2Parser(namespaces=self.namespaces, variables=self.variables)
+
+        # Make sure the tests are repeatable.
+        self.should_set_lc_all_after_tests = 'LC_ALL' in os.environ
+        self.lc_all = os.environ.get('LC_ALL')
+        if self.should_set_lc_all_after_tests:
+            del os.environ['LC_ALL']
+
+    def tearDown(self):
+        if getattr(self, 'should_set_lc_all_after_tests', False):
+            os.environ['LC_ALL'] = self.lc_all
 
     def test_xpath_tokenizer2(self):
         self.check_tokenizer("(: this is a comment :)",

--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -62,14 +62,16 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
         self.parser = XPath2Parser(namespaces=self.namespaces, variables=self.variables)
 
         # Make sure the tests are repeatable.
-        self.should_set_lc_all_after_tests = 'LC_ALL' in os.environ
-        self.lc_all = os.environ.get('LC_ALL')
-        if self.should_set_lc_all_after_tests:
-            del os.environ['LC_ALL']
+        env_vars_to_tweak = 'LC_ALL', 'LANG'
+        self.current_env_vars = {v: os.environ.get(v) for v in env_vars_to_tweak}
+        for v in self.current_env_vars:
+            os.environ[v] = 'en_US.UTF-8'
 
     def tearDown(self):
-        if getattr(self, 'should_set_lc_all_after_tests', False):
-            os.environ['LC_ALL'] = self.lc_all
+        if hasattr(self, 'current_env_vars'):
+            for v in self.current_env_vars:
+                if self.current_env_vars[v] is not None:
+                    os.environ[v] = self.current_env_vars[v]
 
     def test_xpath_tokenizer2(self):
         self.check_tokenizer("(: this is a comment :)",


### PR DESCRIPTION
Some build tools, such as `pybuild`, set the `LC_ALL` and / or `LANG` environment variables to 'C.UTF-8'. This is causing 'test_compare_strings_function' to fail on the 'Straße' compares.

The same behavior is happening on some Linux systems where this environment variable is set.

We would ideally like to have repeatable tests, independent from the environment.

This pull requests enforce a sensible value for these variables.

To reproduce the error on a Linux system, run either:

`LC_ALL="C.UTF-8" python setup.py test`

`LANG="C.UTF-8" python setup.py test`

The error is:

```
======================================================================
FAIL: test_compare_strings_function (tests.test_xpath2_parser.LxmlXPath2ParserTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/guillaume/git/lib/elementpath/tests/test_xpath2_parser.py", line 373, in test_compare_strings_function
    self.check_value(u"fn:compare('Strassen', 'Straße')", 1)
  File "/home/guillaume/git/lib/elementpath/tests/test_xpath1_parser.py", line 156, in check_value
    self.assertEqual(root_token.evaluate(context), expected)
AssertionError: -1 != 1

======================================================================
FAIL: test_compare_strings_function (tests.test_xpath2_parser.XPath2ParserTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/guillaume/git/lib/elementpath/tests/test_xpath2_parser.py", line 373, in test_compare_strings_function
    self.check_value(u"fn:compare('Strassen', 'Straße')", 1)
  File "/home/guillaume/git/lib/elementpath/tests/test_xpath1_parser.py", line 156, in check_value
    self.assertEqual(root_token.evaluate(context), expected)
AssertionError: -1 != 1
```