### PR TITLE
Fix literal cls select method change context.item

### DIFF
--- a/elementpath/tdop_parser.py
+++ b/elementpath/tdop_parser.py
@@ -628,7 +628,10 @@ class Parser(object):
         def evaluate(self, *args, **kwargs):
             return self.value
 
-        return cls.register(symbol, label='literal', lbp=bp, evaluate=evaluate, nud=nud)
+        def select(self, context=None):
+            yield self.evaluate()
+
+        return cls.register(symbol, label='literal', evaluate=evaluate, lbp=bp, nud=nud, select=select)
 
     @classmethod
     def nullary(cls, symbol, bp=0):


### PR DESCRIPTION
hi! Here is my example code not working. 

```python
from elementpath import select
from lxml import etree

root = etree.fromstring(
     """
        <html>
            <ul>
                <li>
                    <span class='class_a'>a</span>
                </li>
            </ul>
        </html>
    """
)
path = "//span[concat('', '', @class)='class_a']/text()"
assert root.xpath(path) == select(root, path) == ["a"]
```

I find this bug when using cssselect to translate **CSSSelectors** expression into **XPath** expression. 

`span.class_a` -> `descendant-or-self::span[@class and contains(concat(' ', normalize-space(@class), ' '), ' class_a ')]`

I do some digging, find out the `literal` parent class's `select` method will change `context.item` value into `literal.value` on line 84.

https://github.com/sissaschool/elementpath/blob/cc23d37027bff39c3c758e8a9058fb054e2ed521/elementpath/xpath_token.py#L71-L85