### PR TITLE
Add support for xs:decimal conversion of Elements

### DIFF
--- a/elementpath/xpath2_parser.py
+++ b/elementpath/xpath2_parser.py
@@ -280,7 +280,10 @@ class XPath2Parser(XPath1Parser):
             if item is None:
                 return []
             try:
-                return self.cast(item)
+                if is_element_node(item):
+                    return self.cast(item.text)
+                else:
+                    return self.cast(item)
             except ElementPathError as err:
                 if err.token is None:
                     err.token = self

--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -713,6 +713,19 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
                 context = XPathContext(self.etree.XML('<root b="0"/>'))
                 self.assertTrue(root_token.evaluate(context=context) is True)
 
+    def test_element_decimal_cast(self):
+        root = self.etree.XML('''
+        <books>
+            <book><isbn>1558604820</isbn><price>12.50</price></book>
+            <book><isbn>1558604820</isbn><price>13.50</price></book>
+            <book><isbn>1558604820</isbn><price>-0.1</price></book>
+        </books>''')
+        expected_values = [ Decimal('12.5'), Decimal('13.5'), Decimal('-0.1') ]
+        self.assertEqual(3, len(select(root, "//book")))
+        for book in iter_select(root, "//book"):
+            context = XPathContext(root=root, item=book)
+            root_token = self.parser.parse("xs:decimal(price)")
+            self.assertEqual(expected_values.pop(0), root_token.evaluate(context))
 
 @unittest.skipIf(lxml_etree is None, "The lxml library is not installed")
 class LxmlXPath2ParserTest(XPath2ParserTest):


### PR DESCRIPTION
Hi,

great work on elementpath! You can't imagine how happy I am to see an implementation of XPath 2 for Python.

I am working on a schematron validation tool, and while working on it, I ran into a number of issues in the parser (while using external XSLT2-based schematron files, so I don't always have control over their context, and arguably the only thing that can be said about them is that they work with Saxon). Some of which are very simple, some of which are not. This is the first of a number of pull requests to try and fix those.

Of course I am far from sure whether the fixes are the right approach, or whether they should be done in a different place; therefor I shall submit them all separately, and provide examples and unit tests where possible.

This one add automatic type coercion for Decimal values