### PR TITLE
Remove conversion to float in rounding function

### DIFF
--- a/elementpath/xpath1_parser.py
+++ b/elementpath/xpath1_parser.py
@@ -1207,9 +1207,9 @@ def evaluate(self, context=None):
     try:
         number = decimal.Decimal(arg)
         if number > 0:
-            return float(number.quantize(decimal.Decimal('1'), rounding='ROUND_HALF_UP'))
+            return number.quantize(decimal.Decimal('1'), rounding='ROUND_HALF_UP')
         else:
-            return float(round(number))
+            return round(number)
     except TypeError as err:
         self.wrong_type(str(err))
     except decimal.DecimalException as err:

--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -714,6 +714,9 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
                 self.assertTrue(root_token.evaluate(context=context) is True)
 
 
+    def test_element_decimal_comparison_after_round(self):
+        self.check_value('xs:decimal(0.36) = round(0.36*100) div 100', True)
+
 @unittest.skipIf(lxml_etree is None, "The lxml library is not installed")
 class LxmlXPath2ParserTest(XPath2ParserTest):
     etree = lxml_etree


### PR DESCRIPTION
See #19 for a short introduction.

Casting the result to float causes floating point errors, so this patch removes that cast