### PR TITLE
Interpret * as select if not actually in infix context

### DIFF
--- a/elementpath/xpath1_parser.py
+++ b/elementpath/xpath1_parser.py
@@ -570,6 +570,9 @@ def evaluate(self, context=None):
                 return op1 * op2
             except TypeError as err:
                 raise self.wrong_type(str(err))
+    else:
+        # This is not a multiplication operator but a wildcard select statement
+        return [x for x in self.select(context)]
 
 
 @method(infix('div', bp=45))

--- a/tests/test_xpath1_parser.py
+++ b/tests/test_xpath1_parser.py
@@ -679,6 +679,20 @@ class XPath1ParserTest(xpath_test_class.XPathTestCase):
         else:
             self.check_value("boolean(())", False)
 
+    def test_nonempty_elements(self):
+        root = self.etree.XML("""<a> <b>text</b> </a>""")
+        context = XPathContext(root=root)
+
+        root_token = self.parser.parse("normalize-space(text()) = ''")
+        self.assertEqual(True, root_token.evaluate(context))
+
+        elements = select(root, "//*")
+        for element in elements:
+            context = XPathContext(root=root, item=element)
+
+            root_token = self.parser.parse("* or normalize-space(text()) != ''")
+            self.assertEqual(True, root_token.evaluate(context), element)
+
     def test_lang_function(self):
         # From https://www.w3.org/TR/1999/REC-xpath-19991116/#section-Boolean-Functions
         self.check_selector('lang("en")', self.etree.XML('<para xml:lang="en"/>'), True)


### PR DESCRIPTION
See #19 for a short introduction.

This patch makes the parser interpret * as a select if not in an actual infix context, so an evaluation of for instance "*" does not return None.

I am not sure about this one; it feels like the current location of the check is not the right one, but I wasn't sure where else to do it.