### PR TITLE
Use select() instead of get_results() in boolean context

### DIFF
--- a/elementpath/xpath1_parser.py
+++ b/elementpath/xpath1_parser.py
@@ -1102,12 +1102,12 @@ def evaluate(self, context=None):
 # Boolean functions
 @method(function('boolean', nargs=1))
 def evaluate(self, context=None):
-    return self.boolean_value(self[0].get_results(context))
+    return self.boolean_value([x for x in self[0].select(context)])
 
 
 @method(function('not', nargs=1))
 def evaluate(self, context=None):
-    return not self.boolean_value(self[0].get_results(context))
+    return not self.boolean_value([x for x in self[0].select(context)])
 
 
 @method(function('true', nargs=0))

--- a/elementpath/xpath2_constructors.py
+++ b/elementpath/xpath2_constructors.py
@@ -491,7 +491,7 @@ def nud(self):
 @method('boolean')
 def evaluate(self, context=None):
     if self.label == 'function':
-        return self.boolean_value(self[0].get_results(context))
+        return self.boolean_value([x for x in self[0].select(context)])
 
     # xs:boolean constructor
     item = self.get_argument(context)

--- a/tests/test_xpath1_parser.py
+++ b/tests/test_xpath1_parser.py
@@ -679,6 +679,18 @@ class XPath1ParserTest(xpath_test_class.XPathTestCase):
         else:
             self.check_value("boolean(())", False)
 
+    def test_boolean_context_nonempty_elements(self):
+        root = self.etree.XML("""<a> <b>text</b> </a>""")
+        context = XPathContext(root=root)
+
+        root_token = self.parser.parse("boolean(node())")
+        self.assertEqual(True, root_token.evaluate(context))
+
+        root_token = self.parser.parse("not(node())")
+        self.assertEqual(False, root_token.evaluate(context))
+        root_token = self.parser.parse("not(not(node()))")
+        self.assertEqual(True, root_token.evaluate(context))
+
     def test_lang_function(self):
         # From https://www.w3.org/TR/1999/REC-xpath-19991116/#section-Boolean-Functions
         self.check_selector('lang("en")', self.etree.XML('<para xml:lang="en"/>'), True)


### PR DESCRIPTION
See #19 for a short introduction.

Using get_results would cause Text nodes to be evaluated and converted into strings, causing the effective boolean value to fail (since whitespace in an element would be a string at that check, instead of the text node), so this patch changes that to use select() instead of get_results()