### PR TITLE
Only check existence of value in empty() and exists()

### DIFF
--- a/elementpath/xpath2_functions.py
+++ b/elementpath/xpath2_functions.py
@@ -299,17 +299,16 @@ def evaluate(self, context=None):
 @method('empty')
 def select(self, context=None):
     for k, value in enumerate(self[0].select(context)):
-        if k or value:
+        if value is not None:
             yield False
             break
     else:
         yield True
 
-
 @method('exists')
 def select(self, context=None):
     for k, value in enumerate(self[0].select(context)):
-        if k or not value:
+        if value is not None:
             yield True
             break
     else:

--- a/tests/test_xpath2_functions.py
+++ b/tests/test_xpath2_functions.py
@@ -522,11 +522,14 @@ class XPath2FunctionsTest(xpath_test_class.XPathTestCase):
         self.check_value('fn:empty(fn:remove(("hello", "world"), 1))', False)
         self.check_value('fn:empty(())', True)
         self.check_value('fn:empty(fn:remove(("hello"), 1))', True)
+        self.check_value('fn:empty((xs:double("0")))', False)
+
 
     def test_exists_function(self):
         self.check_value('fn:exists(("hello", "world"))', True)
         self.check_value('fn:exists(())', False)
         self.check_value('fn:exists(fn:remove(("hello"), 1))', False)
+        self.check_value('fn:exists((xs:int("-1873914410")))', True)
 
     def test_distinct_values_function(self):
         self.check_value('fn:distinct-values((1, 2.0, 3, 2))', [1, 2.0, 3])


### PR DESCRIPTION
I'm almost done, I swear ;) (this is the last one that I have a PR for; I may have one other issue but I'm not sure whether or how to fix it, and I do have a workaround for that right now in my own code).

Regarding this patch:

TBH, I am not sure why 'k' was used there in the first place, so I may be missing something, but 'value' could evaluate (in python) to False, if the expression happens to end up being the int 0 or boolean false, for instance.

There we no regressions due to this change in the internal testset, and when ran against the W3C testset I get the following summary:

```
Summary of differences:
    status parse_error: no change
    status evaluate_error: no change
    status execute_error: no change
    status testcode_error: no change
    status success: +47
    status failed: -47
```

I have picked two of those tests (one for fn:empty, one for fn:exists) at random to include in the internal unit tests.