### PR TITLE
First stab at fixing and testing preceding-sibling::text() and following-sibling::text() issue raised as issue 42

### DIFF
--- a/elementpath/xpath_context.py
+++ b/elementpath/xpath_context.py
@@ -554,6 +554,9 @@ class XPathContext:
         self.axis = axis or 'following-sibling'
 
         if axis == 'preceding-sibling':
+            if parent.text is not None:
+                self.item = TextNode(parent.text, parent)
+                yield self.item
             for child in parent:  # pragma: no cover
                 if child is item:
                     break
@@ -564,6 +567,9 @@ class XPathContext:
                     yield self.item
         else:
             follows = False
+            if parent.text is not None:
+                self.item = TextNode(parent.text, parent)
+                yield self.item
             for child in parent:
                 if follows:
                     self.item = child
@@ -573,6 +579,9 @@ class XPathContext:
                         yield self.item
                 elif child is item:
                     follows = True
+                    if child.tail is not None:
+                        self.item = TextNode(child.tail, child, True)
+                        yield self.item
 
         self.item, self.axis = status
 

--- a/tests/test_selectors.py
+++ b/tests/test_selectors.py
@@ -49,6 +49,17 @@ class XPathSelectorsTest(unittest.TestCase):
         root = ElementTree.XML('<FullPath>High Temp</FullPath>')
         self.assertListEqual(selector.select(root), [root])
 
+    def test_issue_042(self):
+        selector1 = Selector('text()')
+        selector2 = Selector('sup[last()]/preceding-sibling::text()')
+        root = ElementTree.XML('<root>a<sup>1</sup>b<sup>2</sup>c<sup>3</sup></root>')
+        self.assertListEqual(selector1.select(root), selector2.select(root))
+
+        selector2 = Selector('sup[1]/following-sibling::text()')
+        root = ElementTree.XML('<root><sup>1</sup>b<sup>2</sup>c<sup>3</sup>d</root>')
+        self.assertListEqual(selector1.select(root), selector2.select(root))
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I found some problems with `following-sibling::text()` and `preceding-sibling::text()`, see issue https://github.com/sissaschool/elementpath/issues/42, and have tried to fix the obvious omissions to process `parent.text` and/or `item.text`.