### PR TITLE
fix zero length Base64 attribute

### DIFF
--- a/elementpath/datatypes/binary.py
+++ b/elementpath/datatypes/binary.py
@@ -144,14 +144,14 @@ class Base64Binary(AbstractBinary):
         return hash(self.value)
 
     def __len__(self) -> int:
-        length = len(self.value) // 4 * 3
+        length = len(self.value)
         if length == 0:
             return 0
         elif self.value[-2] == ord('='):
-            return length - 2
+            return length // 4 * 3 - 2
         elif self.value[-1] == ord('='):
-            return length - 1
-        return length
+            return length // 4 * 3 - 1
+        return length // 4 * 3
 
     @staticmethod
     def encoder(value: bytes) -> bytes:

--- a/elementpath/datatypes/binary.py
+++ b/elementpath/datatypes/binary.py
@@ -144,11 +144,14 @@ class Base64Binary(AbstractBinary):
         return hash(self.value)
 
     def __len__(self) -> int:
-        if self.value[-2] == ord('='):
-            return len(self.value) // 4 * 3 - 2
+        length = len(self.value) // 4 * 3
+        if length == 0:
+            return 0
+        elif self.value[-2] == ord('='):
+            return length - 2
         elif self.value[-1] == ord('='):
-            return len(self.value) // 4 * 3 - 1
-        return len(self.value) // 4 * 3
+            return length - 1
+        return length
 
     @staticmethod
     def encoder(value: bytes) -> bytes:

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1440,7 +1440,8 @@ class BinaryTypesTest(unittest.TestCase):
         self.assertEqual(hash(HexBinary(b'F859')), hash(b'F859'))
 
     def test_length(self):
-        self.assertEqual(len(Base64Binary(b'ZQ==')), 1)
+        self.assertEqual(len(Base64Binary(b'')), 0)
+        self.assertEqual(len(Base64Binary(b'ZQ==')), 1),
         self.assertEqual(len(Base64Binary(b'YWxwaGE=')), 5)
         self.assertEqual(len(Base64Binary(b'bGNlbmdnamh4eXBy')), 12)
         self.assertEqual(len(HexBinary(b'F859')), 2)


### PR DESCRIPTION
When accessing the length of an attribute with zero length an exception is thrown
this should fix it