### PR TITLE
fix html input parsing problem

### DIFF
--- a/elementpath/xpath_nodes.py
+++ b/elementpath/xpath_nodes.py
@@ -1278,7 +1278,7 @@ class EtreeElementNode(ElementNode):
             return match_wildcard(self.obj.tag, name)
         elif not name:
             return not self.obj.tag
-        elif hasattr(self.obj, 'type'):
+        elif hasattr(self.obj, 'type') and hasattr(self.obj, 'is_matching'):
             return cast(XsdElementProtocol, self.obj).is_matching(name, default_namespace)
         elif name[0] == '{' or not default_namespace:
             return self.obj.tag == name

--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -43,8 +43,10 @@ except ImportError:
 
 try:
     import lxml.etree as lxml_etree
+    import lxml.html as lxml_html
 except ImportError:
     lxml_etree = None
+    lxml_html = None
 
 try:
     import xmlschema
@@ -1520,6 +1522,12 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
 
         results = select(root, 'min(.//row/count(entry))', parser=self.parser.__class__)
         self.assertEqual(results, 1)
+
+    def test_input_selector(self):
+        body = '<input/>'
+        root = self.etree.fromstring(body, parser=lxml_html.HTMLParser())
+        result = select(root, '//input')
+        self.assertEqual(len(result), 1)
 
 
 @unittest.skipIf(lxml_etree is None, "The lxml library is not installed")

--- a/tests/test_xpath2_parser.py
+++ b/tests/test_xpath2_parser.py
@@ -1523,16 +1523,16 @@ class XPath2ParserTest(test_xpath1_parser.XPath1ParserTest):
         results = select(root, 'min(.//row/count(entry))', parser=self.parser.__class__)
         self.assertEqual(results, 1)
 
+
+@unittest.skipIf(lxml_etree is None, "The lxml library is not installed")
+class LxmlXPath2ParserTest(XPath2ParserTest):
+    etree = lxml_etree
+
     def test_input_selector(self):
         body = '<input/>'
         root = self.etree.fromstring(body, parser=lxml_html.HTMLParser())
         result = select(root, '//input')
         self.assertEqual(len(result), 1)
-
-
-@unittest.skipIf(lxml_etree is None, "The lxml library is not installed")
-class LxmlXPath2ParserTest(XPath2ParserTest):
-    etree = lxml_etree
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Lxml html parser InputElement has attribute 'type' as mention here:
https://lxml.de/api/lxml.html.InputElement-class.html

And this elements wrongly detected as XsdElementProtocol.

Possibly this solution is not optimal