### PR TITLE
Drop shebang from categories_fallback.py

### DIFF
--- a/elementpath/regex/categories_fallback.py
+++ b/elementpath/regex/categories_fallback.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 #
 # Copyright (c), 2025, SISSA (International School for Advanced Studies).
 # All rights reserved.


### PR DESCRIPTION
The `elementpath/regex/categories_fallback.py` file cannot be executed:
```
$ elementpath/regex/categories_fallback.py
Traceback (most recent call last):
  File "/data/builds/elementpath/elementpath/regex/categories_fallback.py", line 16, in <module>
    from .unicode_subsets import UnicodeSubset
ImportError: attempted relative import with no known parent package
$
```
So let's remove the shebang and the executable flag from the file.