### PR TITLE
changed function error code for external function processing

### DIFF
--- a/elementpath/xpath_tokens/functions.py
+++ b/elementpath/xpath_tokens/functions.py
@@ -413,12 +413,12 @@ class ExternalFunction(XPathFunction):
             for k, (arg, st) in enumerate(zip(args, self.sequence_types), start=1):
                 if not match_sequence_type(arg, st, self.parser):
                     msg = f"{ordinal(k)} argument does not match sequence type {st!r}"
-                    raise self.error('XPDY0050', msg)
+                    raise self.error('XPTY0004', msg)
 
             result = self.callback(*args)
             if not match_sequence_type(result, self.sequence_types[-1], self.parser):
                 msg = f"Result does not match sequence type {self.sequence_types[-1]!r}"
-                raise self.error('XPDY0050', msg)
+                raise self.error('XPTY0004', msg)
             return result
 
         return self.callback(*args)


### PR DESCRIPTION
I am running a test suite and found that it expects error XPTY0004 in a situation where a custom function is passed an invalid type (it expects element(x:a) as defined in the function signature, is instead passed element(x:b)). Elementpath as currently written raises XPDY0050. Looking into the underlying spec, XPTY0004 does seem like the correct error for this case. The [spec](https://www.w3.org/TR/xpath20/#id-function-calls) defines that 

```If, after the above conversions, the resulting value does not match the expected type according to the rules for SequenceType Matching, a type error is raised [err:XPTY0004]. Note that the rules for SequenceType Matching permit a value of a derived type to be substituted for a value of its base type.```

Meanwhile the error definition for XPDY0050 defines it as a failure of a `treat` expression, which does not seem to be relevant to this situation.

Very quick PR to substitute the error codes in this case.