### PR TITLE
Add "and" before trailing sub-hundred remainder in int_to_words

### DIFF
--- a/elementpath/xpath30/xpath30_helpers.py
+++ b/elementpath/xpath30/xpath30_helpers.py
@@ -312,6 +312,11 @@ def int_to_words(num: int, lang: Optional[str] = None, fmt_modifier: str = '') -
                 elif base == 100:
                     if lang == 'en':
                         yield ' and '
+                elif lang == 'en' and value < 100:
+                    # British convention: "and" before a trailing sub-hundred
+                    # remainder when no hundreds word follows to carry it,
+                    # e.g. "one thousand and one" like "one hundred and one".
+                    yield ' and '
                 else:
                     yield ' '
 

--- a/tests/test_xpath30.py
+++ b/tests/test_xpath30.py
@@ -312,6 +312,21 @@ class XPath30ParserTest(test_xpath2_parser.XPath2ParserTest):
         self.assertEqual(int_to_words(1), 'one')
         self.assertEqual(int_to_words(4), 'four')
 
+        # "and" before a trailing sub-hundred remainder after thousand/million/
+        # billion scales, consistent with "one hundred and one".
+        self.assertEqual(int_to_words(1001), 'one thousand and one')
+        self.assertEqual(int_to_words(8054), 'eight thousand and fifty-four')
+        self.assertEqual(int_to_words(1000001), 'one million and one')
+        self.assertEqual(int_to_words(1000000005), 'one billion and five')
+        self.assertEqual(int_to_words(100001), 'one hundred thousand and one')
+
+        # No spurious "and" for round numbers or when a hundreds word follows.
+        self.assertEqual(int_to_words(1000), 'one thousand')
+        self.assertEqual(int_to_words(1100), 'one thousand one hundred')
+        self.assertEqual(
+            int_to_words(1234), 'one thousand two hundred and thirty-four'
+        )
+
 
 @unittest.skipIf(lxml_etree is None, "The lxml library is not installed")
 class LxmlXPath30ParserTest(XPath30ParserTest):


### PR DESCRIPTION
## Summary

`int_to_words` (used by `fn:format-integer` with the `'w'` picture) follows the British convention of inserting "and" before a trailing sub-hundred remainder — but only after a **hundreds** word, not after the thousand/million/billion scales:

```python
>>> from elementpath.xpath30.xpath30_helpers import int_to_words
>>> int_to_words(101)
'one hundred and one'
>>> int_to_words(1001)
'one thousand one'          # expected 'one thousand and one'
>>> int_to_words(8054)
'eight thousand fifty-four' # expected 'eight thousand and fifty-four'
>>> int_to_words(1000001)
'one million one'           # expected 'one million and one'
```

The output is internally inconsistent: `format-integer(8754, 'w')` → "eight thousand seven hundred and fifty-four" (with "and", because hundreds are present), but `format-integer(8054, 'w')` → "eight thousand fifty-four" (no "and") for the same magnitude. The library's own tested convention uses "and" (`format-integer(123, 'w')` → "one hundred and twenty-three").

## Root cause

In `word_num` (`xpath30_helpers.py`), the post-word separator yields `' and '` for the `base == 100` branch but an unconditional `' '` for the `base >= 1000` branch, even when the remaining value is below one hundred (so no hundreds word follows to carry the "and").

## Fix

Mirror the hundreds branch: for English, when the trailing remainder is `< 100`, yield `' and '`. At that point the remainder is guaranteed non-zero (the loop breaks on a zero remainder), so round numbers are unaffected.

## Verification

- Reproduced on `master` (`537702d`). After the fix: `1001`→"one thousand and one", `8054`→"eight thousand and fifty-four", `1000001`→"one million and one", `1000000005`→"one billion and five", `100001`→"one hundred thousand and one".
- No spurious "and": `1000`→"one thousand", `1100`→"one thousand one hundred", `1234`→"one thousand two hundred and thirty-four". Other languages (e.g. `it`) and the ordinal path are unaffected.
- Extended `test_int_to_words` with these cases; it fails before the fix and passes after (base and lxml subclasses).
- Full suite: **2609 passed, 2 skipped**, no regressions. `flake8` and `mypy` clean.

---

This pull request was prepared with the assistance of AI, under my direction and review.
